### PR TITLE
Add Support for custom esbuild config files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
     "name": "functions-differ",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "0.0.1",
+            "name": "functions-differ",
+            "version": "0.0.2",
             "license": "ISC",
             "dependencies": {
                 "@types/command-line-args": "^5.0.0",
@@ -14,6 +15,9 @@
                 "esbuild": "^0.11.12",
                 "neverthrow": "^4.2.1",
                 "signale": "^1.4.0"
+            },
+            "bin": {
+                "functions-differ": "lib/index.js"
             },
             "devDependencies": {
                 "@types/args": "^3.0.0",

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -7,15 +7,17 @@ const options: OptionDefinition[] = [
     { name: "verbose", alias: "v", type: Boolean, defaultValue: false },
     { name: "prefix", type: String, defaultValue: "functions:" },
     { name: "sep", type: String, defaultValue: "," },
+    { name: "bundlerConfig", type: String, defaultValue: "" }
 ];
 
 const args = cmdArgs(options, { partial: true });
-const { dir, write, verbose, prefix, sep: separator } = args;
+const { dir, write, verbose, prefix, sep: separator, bundlerConfig } = args;
 if (!dir) {
     console.error("Error: dir argument not supplied");
     process.exit(1);
 }
 
 const specFilePath: string = path.join(dir, ".differspec.json");
+const bundlerConfigFilePath: string = bundlerConfig ? path.join(dir, bundlerConfig) : "";
 
-export { specFilePath, dir, write, verbose, prefix, separator };
+export { specFilePath, dir, write, verbose, prefix, separator, bundlerConfigFilePath };

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -2,9 +2,10 @@ import { promises as fs, Stats } from "fs";
 import path from "path";
 import { err, ok, Result } from "neverthrow";
 import DifferSpec, { ParseError } from "./differSpec";
+import { BuildOptions } from "esbuild";
 
 export default async function parseSpecFile(specFilePath: string): Promise<Result<DifferSpec, ParseError>> {
-    const statResult = await specFileStat(specFilePath);
+    const statResult = await checkFileStat(specFilePath);
     if (statResult.isErr()) {
         return err(statResult.error);
     }
@@ -39,7 +40,7 @@ export function resolveFunctionPaths(functions: Record<string, string>, specFile
         }, <Record<string, string>>{});
 }
 
-async function specFileStat(path: string): Promise<Result<Stats, ParseError>> {
+async function checkFileStat(path: string): Promise<Result<Stats, ParseError>> {
     try {
         const stat = await fs.stat(path);
         return ok(stat);
@@ -68,5 +69,38 @@ function parseSpecContents(spec: string): Result<DifferSpec, ParseError> {
         return ok(parsedSpec);
     } catch (error) {
         return err(new ParseError("invalid-json", "Failed to parse spec file as JSON"));
+    }
+}
+
+export async function parseBundlerConfigFile(path: string): Promise<Result<BuildOptions, ParseError>> {
+    if (path === "") {
+        return ok({});
+    }
+
+    const statResult = await checkFileStat(path);
+    if (statResult.isErr()) {
+        return err(statResult.error);
+    }
+    const specContentsResult = await readSpecContents(path);
+    if (specContentsResult.isErr()) {
+        return err(specContentsResult.error);
+    }
+
+    const specContents = specContentsResult.value;
+    const bundlerConfigSpecResult = parseBundlerConfig(specContents);
+    if (bundlerConfigSpecResult.isErr()) {
+        return err(bundlerConfigSpecResult.error);
+    }
+
+    const bundlerConfig = bundlerConfigSpecResult.value;
+    return ok(bundlerConfig);
+}
+
+function parseBundlerConfig(spec: string): Result<BuildOptions, ParseError> {
+    try {
+        const parsedSpec = JSON.parse(spec);
+        return ok(parsedSpec);
+    } catch (error) {
+        return err(new ParseError("invalid-json", "Failed to parse bundler config spec file as JSON"));
     }
 }


### PR DESCRIPTION
Addresses this [issue](https://github.com/haroldadmin/functions-differ/issues/7)

Changes: 

1. Add another optional argument for the CLI
2. Parse the file passed as the `BuildOptions` config file 
3. Pass the parsed `BuildOptions` to the bundler 