### PR TITLE
Add ability to control bundling concurrency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
     "name": "functions-differ",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "functions-differ",
-            "version": "0.1.0",
+            "version": "0.1.1",
             "license": "ISC",
             "dependencies": {
+                "@supercharge/promise-pool": "^2.1.0",
                 "@types/command-line-args": "^5.0.0",
                 "chalk": "^4.1.2",
                 "command-line-args": "^5.1.1",
@@ -120,6 +121,14 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@supercharge/promise-pool": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@supercharge/promise-pool/-/promise-pool-2.1.0.tgz",
+            "integrity": "sha512-YEKOfn4xF+DQ61UY5NwHNtr8hYjwchXjGTocVJDAHLQceIRZF8VECH7gumFbp+aGTfygPbMbEtBumXJ/mcJz+w==",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/@types/args": {
@@ -2963,6 +2972,11 @@
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
             }
+        },
+        "@supercharge/promise-pool": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@supercharge/promise-pool/-/promise-pool-2.1.0.tgz",
+            "integrity": "sha512-YEKOfn4xF+DQ61UY5NwHNtr8hYjwchXjGTocVJDAHLQceIRZF8VECH7gumFbp+aGTfygPbMbEtBumXJ/mcJz+w=="
         },
         "@types/args": {
             "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "author": "Kshitij Chauhan",
     "license": "ISC",
     "dependencies": {
+        "@supercharge/promise-pool": "^2.1.0",
         "@types/command-line-args": "^5.0.0",
         "chalk": "^4.1.2",
         "command-line-args": "^5.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,12 @@
 
 import chalk from "chalk";
 import { bundleFunctions } from "./bundler";
+import { BundlerConfig } from "./bundler/esbuild";
 import hashesDiffer from "./differ/differ";
 import calculateHash from "./hasher/hasher";
 import segregate from "./hasher/segregate";
 import logger from "./logger";
-import { bundlerConfigFilePath, dir, prefix, separator, specFilePath, write } from "./options/options";
+import { bundlerConfigFilePath, concurrency, dir, prefix, separator, specFilePath, write } from "./options/options";
 import DifferSpec from "./parser/differSpec";
 import parseSpecFile, { parseBundlerConfigFile, resolveFunctionPaths } from "./parser/parser";
 import writeSpec from "./parser/writer";
@@ -24,7 +25,10 @@ async function main() {
         logger.error(bundlerConfigSpecResult.error);
         return;
     }
-    const bundlerConfig = bundlerConfigSpecResult.value;
+    const bundlerConfig: BundlerConfig = {
+        ...bundlerConfigSpecResult.value,
+        concurrency,
+    };
 
     const { functions, hashes: existingHashes } = specResult.value;
     logger.info(`Discovered ${Object.keys(functions).length} functions`);

--- a/src/options/options.spec.ts
+++ b/src/options/options.spec.ts
@@ -1,0 +1,11 @@
+import { expect } from "chai";
+import commandLineArgs from "command-line-args";
+import { options } from "./options";
+
+describe("options parsing", () => {
+    it("should parse concurrency arg correctly", () => {
+        const cmd = "functions-differ --concurrency 10";
+        const { concurrency } = commandLineArgs(options, { argv: cmd.split(" "), partial: true });
+        expect(concurrency).to.equal(10);
+    });
+});

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -1,17 +1,18 @@
 import cmdArgs, { OptionDefinition } from "command-line-args";
 import path from "path";
 
-const options: OptionDefinition[] = [
+export const options: OptionDefinition[] = [
     { name: "dir", alias: "d", type: String, defaultValue: process.cwd() },
     { name: "write", alias: "w", type: Boolean, defaultValue: true },
     { name: "verbose", alias: "v", type: Boolean, defaultValue: false },
     { name: "prefix", type: String, defaultValue: "functions:" },
     { name: "sep", type: String, defaultValue: "," },
-    { name: "bundlerConfig", type: String, defaultValue: "" }
+    { name: "bundlerConfig", type: String, defaultValue: "" },
+    { name: "concurrency", type: Number },
 ];
 
 const args = cmdArgs(options, { partial: true });
-const { dir, write, verbose, prefix, sep: separator, bundlerConfig } = args;
+const { dir, write, verbose, prefix, sep: separator, bundlerConfig, concurrency } = args;
 if (!dir) {
     console.error("Error: dir argument not supplied");
     process.exit(1);
@@ -20,4 +21,4 @@ if (!dir) {
 const specFilePath: string = path.join(dir, ".differspec.json");
 const bundlerConfigFilePath: string = bundlerConfig ? path.join(dir, bundlerConfig) : "";
 
-export { specFilePath, dir, write, verbose, prefix, separator, bundlerConfigFilePath };
+export { specFilePath, dir, write, verbose, prefix, separator, bundlerConfigFilePath, concurrency };


### PR DESCRIPTION
`functions-differ` bundles all the functions in the `.differspec.json` file in parallel by default. This becomes problematic if the number of functions in a repository is high, as the system can potentially run out of memory. This is especially true for CI runners, such as Github Actions.

This PR introduces a `--concurrency` flag for the command line that lets you control the concurrency of the bundling process.
It's default value is the number of functions specified in the `.differspec.json` file for backward compatibility.

