### PR TITLE
Add a no-discover flag to disable automatic discovery

### DIFF
--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -10,11 +10,14 @@ export const options: OptionDefinition[] = [
     { name: "bundlerConfig", type: String, defaultValue: "" },
     { name: "concurrency", type: Number },
     { name: "discover", type: Boolean, defaultValue: true },
+    { name: "no-discover", type: Boolean },
     { name: "indexFilePath", type: String, defaultValue: undefined },
 ];
 
 const args = cmdArgs(options, { partial: true });
-const { dir, write, verbose, prefix, sep: separator, bundlerConfig, concurrency, discover, indexFilePath } = args;
+const { dir, write, verbose, prefix, sep: separator, bundlerConfig, concurrency, indexFilePath } = args;
+const discover = args.discover && !args["no-discover"];
+
 if (!dir) {
     console.error("Error: dir argument not supplied");
     process.exit(1);


### PR DESCRIPTION
This PR adds a `--no-discover` flag to disable automatic function discovery.

A separate flag is needed because the `command-line-args` library does not support disabling a boolean flag by setting it to false: `--discover=false`.
The `--no-discover` flag lets you do that: `functions differ --no-discover`.

Fixes #12
