### PR TITLE
Add Type Checker based automatic function discovery

### DIFF
--- a/src/discoverer/discoverer.spec.ts
+++ b/src/discoverer/discoverer.spec.ts
@@ -5,9 +5,9 @@ describe("Function Discovery", function () {
     this.timeout(0);
     it("Should return the functions paths correctly", () => {
         const expectedResult = {
-            firstFunction: "/test-e2e/firstFunctions/function.ts",
-            secondFunctionHttpTrigger: "/test-e2e/secondFunction/http.trigger.ts",
-            secondFunctionPubSub: "/test-e2e/secondFunction/pubsub.trigger.ts",
+            firstFunction: "test-e2e/firstFunctions/function.ts",
+            secondFunctionHttpTrigger: "test-e2e/secondFunction/http.trigger.ts",
+            secondFunctionPubSub: "test-e2e/secondFunction/pubsub.trigger.ts",
         };
         const indexFilePath = "test-e2e/index.ts";
         const result = getFirebaseFunctionsAndPaths(indexFilePath);

--- a/src/discoverer/discoverer.ts
+++ b/src/discoverer/discoverer.ts
@@ -1,9 +1,7 @@
-import { ExportDeclaration, ImportDeclaration, Project } from "ts-morph";
-
-const getPath = (declaration: ImportDeclaration | ExportDeclaration): string | undefined => {
-    const sourceFile = declaration.getModuleSpecifierSourceFile()?.getFilePath()?.toString();
-    return sourceFile;
-};
+import { relative } from "path";
+import { cwd } from "process";
+import { Project } from "ts-morph";
+import logger from "../logger";
 
 /**
  * Function to discover and get the paths of all functions
@@ -12,71 +10,31 @@ const getPath = (declaration: ImportDeclaration | ExportDeclaration): string | u
  * @returns {Record<string, string>} A Record containing list of all functions as keys and their paths as values.
  */
 const getExports = (indexFilePath = "src/index.ts"): Record<string, string> => {
-    if (indexFilePath.startsWith("undefined")) {
-        return {};
-    }
-    const sourceFile = project.getSourceFileOrThrow(indexFilePath);
+    const exports: Record<string, string> = {};
 
-    // Build imports map, as imports can have paths
-    const imports = sourceFile.getImportDeclarations();
-    const importMap: Record<string, string> = {};
-    for (const imp of imports) {
-        const path = getPath(imp);
+    const typeChecker = project.getTypeChecker();
+    const indexFile = project.getSourceFileOrThrow(indexFilePath);
 
-        [...imp.getNamedImports(), imp.getDefaultImport()].map((name) => {
-            if (name && path) importMap[name.getText()] = path;
-        });
-    }
+    const exportSymbols = typeChecker.getExportsOfModule(indexFile.getSymbolOrThrow());
+    for (const exportSymbol of exportSymbols) {
+        const exportName = exportSymbol.getName();
+        const aliasedSymbol = exportSymbol.getAliasedSymbol();
 
-    const exports = sourceFile.getExportDeclarations();
-    let exportMap: Record<string, string> = {};
+        const [declaration] = aliasedSymbol ? aliasedSymbol.getDeclarations() : exportSymbol.getDeclarations();
 
-    for (const exp of exports) {
-        const ppath = getPath(exp);
-        const exportedFunctions = exp.getNamedExports();
-
-        for (const func of exportedFunctions) {
-            let path = ppath;
-            if (exportMap[func.getText()]) continue;
-            if (!path) path = importMap[func.getText()];
-
-            // Assumption: Files that import modules from another file and export it have the word "index" in it.
-            // Need to recursively call the getExports function on this index.ts file to get the actual path of the
-            // functions exported from this index file.
-            if (path?.includes("index")) {
-                let currentDir = exp.getModuleSpecifierSourceFile()?.getDirectoryPath();
-
-                // if currentDir is undefined, try to get currentDir from the imports. This can happen if a file has
-                // separate import-export lines for the module
-
-                if (!currentDir) {
-                    const imp = imports.filter((impp) =>
-                        impp
-                            .getNamedImports()
-                            .map((x) => x.getText())
-                            .includes(func.getText()),
-                    );
-                    currentDir = imp[0].getModuleSpecifierSourceFile()?.getDirectoryPath();
-                }
-
-                const deeperExports = getExports(`${currentDir}/index.ts`);
-
-                // if the deeperExports object is empty, it possibly means that
-                // the function was defined in the most recent "index*.ts" file explored
-                // or there was a failure. In both cases, assume the path of the function to be the
-                // most recent "index*.ts" file explored
-                if (Object.keys(deeperExports).length === 0) {
-                    exportMap[func.getText()] = path;
-                } else {
-                    exportMap = { ...exportMap, ...deeperExports };
-                }
-            } else {
-                if (path) exportMap[func.getText()] = path;
-            }
+        if (!declaration) {
+            logger.error(`Failed to find a declaration for ${exportSymbol.getName()}`);
+            continue;
         }
+
+        const filePath = declaration.getSourceFile().getFilePath();
+
+        exports[exportName] = relative(cwd(), filePath);
     }
-    return exportMap;
+
+    return exports;
 };
+
 const project = new Project();
 project.addSourceFilesAtPaths("**/*.ts");
 


### PR DESCRIPTION
This PR migrates the function discovery logic to use the TypeScript compiler's Type Checker tool.

This changes makes the functiond discovery logic a simpler and more robust. We now rely on the semantic information stored in the TypeScript compiler's symbols, instead of manually traversing the AST to infer export paths.

Also see:
- [How can I use the TS Compiler API to find where a variable was defined in another file](https://stackoverflow.com/questions/59838013/how-can-i-use-the-ts-compiler-api-to-find-where-a-variable-was-defined-in-anothe/59847032#59847032)
- [TypeScript Compiler API: how to get literal value by ImportSpecifier node?](https://stackoverflow.com/questions/67530264/typescript-compiler-api-how-to-get-literal-value-by-importspecifier-node/67548123#67548123)


