### PR TITLE
feat: Automatically detect Grouped Functions organised in folders

### DIFF
--- a/src/discoverer/discoverer.spec.ts
+++ b/src/discoverer/discoverer.spec.ts
@@ -8,6 +8,7 @@ describe("Function Discovery", function () {
             firstFunction: "test-e2e/firstFunctions/function.ts",
             secondFunctionHttpTrigger: "test-e2e/secondFunction/http.trigger.ts",
             secondFunctionPubSub: "test-e2e/secondFunction/pubsub.trigger.ts",
+            "nestedFunctions.deeplyNestedFunction": "test-e2e/nestedFunctions/deeplyNested.trigger.ts",
         };
         const indexFilePath = "test-e2e/index.ts";
         const result = getFirebaseFunctionsAndPaths(indexFilePath);

--- a/src/discoverer/discoverer.ts
+++ b/src/discoverer/discoverer.ts
@@ -28,8 +28,14 @@ const getExports = (indexFilePath = "src/index.ts"): Record<string, string> => {
         }
 
         const filePath = declaration.getSourceFile().getFilePath();
-
-        exports[exportName] = relative(cwd(), filePath);
+        if (declaration.getSymbolOrThrow().getExports().length > 0) {
+            const nestedExports = getExports(filePath);
+            for (const [nestedExportName, nestedFilePath] of Object.entries(nestedExports)) {
+                exports[`${exportName}.${nestedExportName}`] = nestedFilePath;
+            }
+        } else {
+            exports[exportName] = relative(cwd(), filePath);
+        }
     }
 
     return exports;

--- a/test-e2e/index.ts
+++ b/test-e2e/index.ts
@@ -1,4 +1,5 @@
 import { firstFunction } from "./firstFunctions/function";
 import { secondFunctionHttpTrigger, secondFunctionPubSub } from "./secondFunction";
+import * as nestedFunctions from "./nestedFunctions";
 
-export { firstFunction, secondFunctionHttpTrigger, secondFunctionPubSub };
+export { firstFunction, secondFunctionHttpTrigger, secondFunctionPubSub, nestedFunctions };

--- a/test-e2e/nestedFunctions/deeplyNested.trigger.ts
+++ b/test-e2e/nestedFunctions/deeplyNested.trigger.ts
@@ -1,0 +1,1 @@
+export function deeplyNestedFunction() {}

--- a/test-e2e/nestedFunctions/index.ts
+++ b/test-e2e/nestedFunctions/index.ts
@@ -1,0 +1,1 @@
+export { deeplyNestedFunction } from "./deeplyNested.trigger";


### PR DESCRIPTION
# Description
This pull request adds a feature to automatically detect nested grouped functions organized in folders. Aligning with the grouping functions pattern as recommended in the Google Firebase Functions documentation.

This fix assumes, functions are defined in a file with just one export. (as defined in the tests)

## Google Firebase Documentation
https://firebase.google.com/docs/functions/organize-functions?gen=1st#group_functions

# Related Issue:
#17 